### PR TITLE
terms with hyphens in them break

### DIFF
--- a/lib/URI/Namespace.pm
+++ b/lib/URI/Namespace.pm
@@ -70,11 +70,16 @@ has uri => (
 	 handles => ['as_string', 'as_iri', 'canonical', 'eq', 'abs', 'rel']
 );
 
+sub _uri {
+    my ($self, $name) = @_;
+    return URI->new($self->uri . "$name");
+}
+
 our $AUTOLOAD;
 sub AUTOLOAD {
   my $self = shift;
   my ($name) = $AUTOLOAD =~ /::(\w+)$/;
-  return URI->new($self->uri . "$name");
+  return $self->_uri($name);
 }
 
 

--- a/lib/URI/NamespaceMap.pm
+++ b/lib/URI/NamespaceMap.pm
@@ -130,7 +130,7 @@ sub uri {
 	}
 	return unless (blessed($ns));
 	if ($local ne '') {
-		return $ns->$local();
+		return $ns->_uri($local);
 	} else {
 		return $ns->uri
 	}
@@ -260,7 +260,9 @@ sub _guess {
 			# This is a prefix
 			carp "Cannot resolve '$entry' without XML::CommonNS or RDF::NS" unless ($xmlns || $rdfns);
 			if ($xmlns) {
-				use XML::CommonNS ':all';
+                use XML::CommonNS ':all';
+				#require XML::CommonNS;
+                #XML::CommonNS->import(':all');
 				$namespaces{$entry} = XML::CommonNS->uri(uc($entry))->toString;
 			}
 			if ((! $namespaces{$entry}) && $rdfns) {


### PR DESCRIPTION
This fixes that.

Also FYI it looks like the prefix guess test fails (also XML::NamespaceFactory should croak rather than die), and make distclean removes stuff under version control. I didn't touch those.

And it might be worth contemplating switching to Moo to trim down the startup time. But that's a different issue.
