### PR TITLE
remove strict/warnings pragmas where Moo is used

### DIFF
--- a/lib/URI/Namespace.pm
+++ b/lib/URI/Namespace.pm
@@ -1,7 +1,4 @@
 package URI::Namespace;
-use strict;
-use warnings;
-
 use Moo 1.006000;
 use URI;
 use IRI 0.003;

--- a/lib/URI/NamespaceMap.pm
+++ b/lib/URI/NamespaceMap.pm
@@ -1,6 +1,4 @@
 package URI::NamespaceMap;
-use strict;
-use warnings;
 use Moo 1.006000;
 use Module::Load::Conditional qw[can_load];
 use URI::Namespace;


### PR DESCRIPTION
Moo's current minimum requirement (1.006000) and above imports the strict and warnings pragmas into calling packages. Explicit use seems redundant.

This is part of the CPAN pull request challenge. I would like to take a look at the issue explicitly flagged for the `cpan-prc` when I get some more time.