### PR TITLE
prohibiting forbidden/reserved local parts

### DIFF
--- a/lib/Types/Namespace.pm
+++ b/lib/Types/Namespace.pm
@@ -17,13 +17,13 @@ Types::Namespace - type constraints for dealing with namespaces
   package Namespace::Counter {
     use Moo;  # or Moose
     use Types::Namespace qw( Namespace );
-    
+
     has ns => (
       is => "ro",
       isa => Namespace,
       required => 1,
     );
-    
+
     sub count_uses_in_document { ... }
   }
 

--- a/lib/URI/Namespace.pm
+++ b/lib/URI/Namespace.pm
@@ -11,7 +11,6 @@ our $VERSION = '0.32';
 
 URI::Namespace - A namespace URI/IRI class with autoload methods
 
-
 =head1 SYNOPSIS
 
   use URI::Namespace;

--- a/lib/URI/NamespaceMap.pm
+++ b/lib/URI/NamespaceMap.pm
@@ -90,7 +90,6 @@ Returns an array of prefixes.
 
 =cut
 
-
 around BUILDARGS => sub {
 	my ($next, $self, @parameters) = @_;
 	if (ref($parameters[0]) eq 'ARRAY') {
@@ -145,8 +144,6 @@ sub guess_and_add {
 	}
 }
 
-
-
 =item C<< uri ( $prefixed_name ) >>
 
 Returns a URI for an abbreviated string such as 'foaf:Person'.
@@ -179,7 +176,6 @@ called in list context) for the given URI.
 
 =cut
 
-
 # turn the URI back into a string to mitigate unexpected behaviour
 sub _scrub_uri {
 	my $uri = shift;
@@ -210,36 +206,36 @@ sub _scrub_uri {
 			            "an unblessed %s reference", ref $uri);
 		}
 	}
-	
+
 	return $uri;
 }
 
 sub prefix_for {
 	my ($self, $uri) = @_;
-	
+
 	$uri = _scrub_uri($uri);
-	
+
 	my @candidates;
 	for my $k ($self->list_prefixes) {
 		my $v = $self->namespace_uri($k);
-		
+
 		my $nsuri = $v->as_string;
-		
+
 		# the input should always be longer than the namespace
 		next if length $nsuri > length $uri;
-		
+
 		# candidate namespace must match exactly
 		my $cns = substr($uri, 0, length $nsuri);
 		push @candidates, $k if $cns eq $nsuri;
 	}
-	
+
 	# make sure this behaves correctly when empty
 	return unless @candidates;
-	
+
 	# if this returns more than one prefix, take the
 	# shortest/lexically lowest one.
 	@candidates = sort @candidates;
-	
+
 	return wantarray ? @candidates : $candidates[0];
 }
 
@@ -256,16 +252,16 @@ may be useful for certain serialization tasks.
 
 sub abbreviate {
 	my ($self, $uri) = @_;
-	
+
 	$uri = _scrub_uri($uri);
-	
+
 	my $prefix = $self->prefix_for($uri);
-	
+
 	# XXX is this actually the most desirable behaviour?
 	return unless defined $prefix;
-	
+
 	my $nsuri = _scrub_uri($self->namespace_uri($prefix));
-	
+
 	return sprintf('%s:%s', $prefix, substr($uri, length $nsuri));
 }
 
@@ -285,10 +281,10 @@ sub _guess {
 	my $xmlns = can_load( modules => { 'XML::CommonNS' => 0 } );
 	my $rdfns = can_load( modules => { 'RDF::NS' => 20130802 } );
 	my $rdfpr = can_load( modules => { 'RDF::Prefixes' => 0 } );
-	
+
 	confess 'To resolve an array, you need at least one of RDF::NS::Curated, XML::CommonNS, RDF::NS or RDF::Prefixes' unless ($rnscu || $xmlns || $rdfns || $rdfpr);
 	my %namespaces;
-	
+
 	foreach my $entry (@data) {
 		if ($entry =~ m/^[a-z]\w+$/i) {
 			# This is a prefix
@@ -334,7 +330,6 @@ sub _guess {
 	}
 	return \%namespaces;
 }
-
 
 =back
 

--- a/lib/URI/NamespaceMap/ReservedLocalParts.pm
+++ b/lib/URI/NamespaceMap/ReservedLocalParts.pm
@@ -1,0 +1,78 @@
+package URI::NamespaceMap::ReservedLocalParts;
+use Moo 1.006000;
+use Types::Standard qw/ArrayRef Str/;
+use List::Util qw/first/;
+
+has allowed => (
+    is      => 'ro',
+    isa     => ArrayRef [Str],
+    default => sub { [qw/allowed disallowed is_reserved/] }
+);
+has disallowed => (is => 'ro', isa => ArrayRef [Str], default => sub { [] });
+
+sub is_reserved {
+    my ($self, $keyword) = @_;
+    return 0 if first { $_ eq $keyword } @{$self->allowed};
+    return 1 if first { $_ eq $keyword } @{$self->disallowed};
+    return $self->can($keyword) ? 1 : 0;
+}
+
+1;
+
+=head1 NAME
+
+URI::NamespaceMap::ReservedLocalParts - Permissible local parts for NamespaceMap
+
+=head1 SYNOPSIS
+
+    my $r = URI::NamespaceMap::ReservedLocalParts->new(disallowed => [qw/uri/]);
+
+    say $r->is_reserved('isa'); # 1
+    say $r->is_reserved('uri'); # 1
+    say $r->is_reserved('foo'); # 0
+
+=head1 DESCRIPTION
+
+L<URI::NamespaceMap::ReservedLocalParts> is an accompanying distribution to
+L<URI::NamespaceMap>. It's goal is to check for forbidden names used for local
+parts.
+
+Rather than creating a blacklist that needs to be maintained, it instantiates
+a new L<Moo> object, and calls C<can> on the invocant. Using this technique, it
+means that every method on every Perl object (C<isa, can, VERSION>), and Moo
+objects (C<BUILD, BUILDARGS>) will be automatically black listed.
+
+=head1 ATTRIBUTES
+
+L<URI::NamespaceMap::ReservedLocalParts> implements the following attributes.
+
+=head2 allowed
+
+A whitelist of local part names. Defaults to C<allowed>, C<disallowed> and
+C<is_reserved> so that when C<can> is called on the instance, it doesn't return
+a false positive for other method names associated with this package.
+
+=head2 disallowed
+
+A blacklist of local part names. Does not have a default set, but usually
+defaults to C<uri> when called from L<URI::NamespaceMap>.
+
+=head1 METHODS
+
+L<URI::NamespaceMap::ReservedLocalParts> implements the following methods.
+
+=head2 is_reserved
+
+    my $r = URI::NamespaceMap::ReservedLocalParts->new(disallowed => [qw/uri/]);
+
+    say $r->is_reserved('isa'); # 1
+    say $r->is_reserved('uri'); # 1
+    say $r->is_reserved('foo'); # 0
+
+Checks if the first argument passed is reserved or not. Returns a C<boolean>.
+
+=head1 FURTHER DETAILS
+
+See L<URI::NamespaceMap> for further details about authors, license, etc.
+
+=cut

--- a/t/justuri.t
+++ b/t/justuri.t
@@ -3,7 +3,6 @@ use Test::More;
 use strict;
 use URI;
 
-
 use_ok('URI::Namespace');
 
 my $foaf = URI::Namespace->new( 'http://xmlns.com/foaf/0.1/' );

--- a/t/namespacemap.t
+++ b/t/namespacemap.t
@@ -39,12 +39,9 @@ my $rdf	= URI::Namespace->new( 'http://www.w3.org/1999/02/22-rdf-syntax-ns#' );
 	isa_ok( $map, 'URI::NamespaceMap' );
 }
 
-TODO: {
-	local $TODO = 'Need to throw a sensible error message if a method is used as local part';
-	throws_ok {
-		my $map		= URI::NamespaceMap->new( { isa => 'http://example.org/ns/isa#' } );
-	} qr/prohibited as local part/, "Throws if isa is used as local part.";
-}
+throws_ok {
+	my $map		= URI::NamespaceMap->new( { isa => 'http://example.org/ns/isa#' } );
+} qr/prohibited as local part/, "Throws if isa is used as local part.";
 
 
 
@@ -110,12 +107,8 @@ is($map->abbreviate($map->uri(':foo')), ':foo', 'abbrev no prefix ');
 
 is($map->abbreviate('http://derp.net/foobar'), undef, 'abbrev no match');
 
-TODO: {
-	local $TODO = 'Need to throw a sensible error message if a method is used as local part';
-	throws_ok {
-		$map->add_mapping( isa => 'http://example.org/ns/isa#' );
-	} qr/prohibited as local part/, "Throws if isa is used as local part.";
-}
-
+throws_ok {
+	$map->add_mapping( isa => 'http://example.org/ns/isa#' );
+} qr/prohibited as local part/, "Throws if isa is used as local part.";
 
 done_testing;

--- a/t/prefixguess-none.t
+++ b/t/prefixguess-none.t
@@ -1,7 +1,6 @@
 use Test::More;
 use Test::Exception;
 
-
 use strict;
 use Module::Load::Conditional qw[check_install];
 
@@ -11,7 +10,7 @@ my $rnscu = check_install( module => 'RDF::NS::Curated');
 my $rdfpr = check_install( module => 'RDF::Prefixes');
 
 if (defined $xmlns || defined $rdfns || defined $rnscu || defined $rdfpr) {
-	plan skip_all => 'One of the namespace modules is installed' 
+	plan skip_all => 'One of the namespace modules is installed'
 }
 
 use_ok('URI::NamespaceMap');

--- a/t/prefixguess.t
+++ b/t/prefixguess.t
@@ -10,7 +10,7 @@ my $rnscu = check_install( module => 'RDF::NS::Curated');
 my $rdfpr = check_install( module => 'RDF::Prefixes');
 
 unless (defined $xmlns || defined $rdfns || defined $rnscu || defined $rdfpr) {
-	plan skip_all => 'None of the namespace modules XML::CommonNS, RDF::NS::Curated, RDF::NS or RDF::Prefixes are installed' 
+	plan skip_all => 'None of the namespace modules XML::CommonNS, RDF::NS::Curated, RDF::NS or RDF::Prefixes are installed'
 }
 
 if (defined $rdfns) {
@@ -60,7 +60,7 @@ SKIP: {
 	is($map->namespace_uri('foaf')->as_string, 'http://xmlns.com/foaf/0.1/', 'FOAF URI string OK');
 	is($map->namespace_uri('rdf')->as_string, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'RDF URI string OK');
 	is_deeply([sort $map->list_prefixes], ['foaf', 'rdf', 'xsd' ], 'Prefix listing OK');
-	
+
 }
 
 SKIP: {

--- a/t/reserved.t
+++ b/t/reserved.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Test::More;
+use URI::NamespaceMap::ReservedLocalParts;
+
+subtest 'allowed/disallowed namespaces by default' => sub {
+    my $r = URI::NamespaceMap::ReservedLocalParts->new();
+
+    for my $ns (qw/can DOES isa VERSION/) {
+        is $r->is_reserved($ns) => 1, "namespace $ns is reserved";
+    }
+
+    for my $ns (qw/allowed disallowed is_reserved uri/) {
+        is $r->is_reserved($ns) => 0, "namespace $ns is *not* reserved";
+    }
+};
+
+subtest 'extending disallowed namespaces' => sub {
+    my $r = URI::NamespaceMap::ReservedLocalParts->new(disallowed => [qw/uri/]);
+    is $r->is_reserved('uri') => 1, 'namespace uri is reserved';
+};
+
+done_testing;


### PR DESCRIPTION
This avoids using the names 'can', 'isa', 'VERSION', and 'DOES' etc. as a namespace prefix.

This PR has been submitted as part of the CPAN pull request challenge.

Fixes #1